### PR TITLE
Add pre-commit configuration and technical manual

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-merge-conflict

--- a/MANUAL_TECNICO.md
+++ b/MANUAL_TECNICO.md
@@ -1,0 +1,36 @@
+# Manual Técnico (Integración de Pre-commit)
+
+Este documento describe cómo configurar y utilizar los ganchos de pre-commit en este proyecto.
+
+## Requisitos previos
+
+1. **Python 3.8 o superior** con la herramienta `pip` disponible.
+2. **Git** para el control de versiones.
+
+## Instalación de pre-commit
+
+1. Instale la herramienta `pre-commit`:
+   ```bash
+   pip install pre-commit
+   ```
+2. Desde la raíz del repositorio, ejecute:
+   ```bash
+   pre-commit install
+   ```
+   Esto configurará los ganchos para que se ejecuten automáticamente al realizar un `git commit`.
+
+## Uso manual
+
+Si desea ejecutar los ganchos de forma manual sobre todo el código:
+```bash
+pre-commit run --all-files
+```
+
+## Hooks configurados
+
+El archivo `.pre-commit-config.yaml` incluye los siguientes hooks del repositorio [pre-commit-hooks](https://github.com/pre-commit/pre-commit-hooks):
+
+- **end-of-file-fixer**: Garantiza que todos los archivos terminen con una línea en blanco.
+- **trailing-whitespace**: Elimina los espacios en blanco al final de cada línea.
+- **check-added-large-files**: Detecta archivos añadidos que superen un tamaño razonable.
+- **check-merge-conflict**: Impide que se suban archivos con marcadores de conflicto de Git.


### PR DESCRIPTION
## Summary
- add `.pre-commit-config.yaml` with standard hooks
- document setup in new manual `MANUAL_TECNICO.md`

## Testing
- `pre-commit run --files .pre-commit-config.yaml MANUAL_TECNICO.md`

------
https://chatgpt.com/codex/tasks/task_e_6840979fc42c8330bae6a540fd51d37d